### PR TITLE
Fix: make MINIOS compile with released Xen 4.5.0

### DIFF
--- a/master/0002-tools-libxc-Implement-writev_exact-in-the-same-style.patch
+++ b/master/0002-tools-libxc-Implement-writev_exact-in-the-same-style.patch
@@ -18,10 +18,11 @@ diff --git a/tools/libxc/xc_private.c b/tools/libxc/xc_private.c
 index 1c214dd..0941b06 100644
 --- a/tools/libxc/xc_private.c
 +++ b/tools/libxc/xc_private.c
-@@ -858,6 +858,66 @@ int write_exact(int fd, const void *data, size_t size)
+@@ -858,6 +858,68 @@ int write_exact(int fd, const void *data, size_t size)
      return 0;
  }
  
++#ifndef __MINIOS__
 +int writev_exact(int fd, const struct iovec *iov, int iovcnt)
 +{
 +    struct iovec *local_iov = NULL;
@@ -81,6 +82,7 @@ index 1c214dd..0941b06 100644
 +    errno = saved_errno;
 +    return rc;
 +}
++#endif
 +
  int xc_ffs8(uint8_t x)
  {
@@ -89,19 +91,23 @@ diff --git a/tools/libxc/xc_private.h b/tools/libxc/xc_private.h
 index 010e00f..5b3f04e 100644
 --- a/tools/libxc/xc_private.h
 +++ b/tools/libxc/xc_private.h
-@@ -28,6 +28,7 @@
+@@ -28,6 +28,9 @@
  #include <sys/stat.h>
  #include <stdlib.h>
  #include <sys/ioctl.h>
++#ifndef __MINIOS__
 +#include <sys/uio.h>
++#endif
  
  #include "_paths.h"
  #include "xenctrl.h"
-@@ -344,6 +345,7 @@ int xc_flush_mmu_updates(xc_interface *xch, struct xc_mmu *mmu);
+@@ -344,6 +345,9 @@ int xc_flush_mmu_updates(xc_interface *xch, struct xc_mmu *mmu);
  /* Return 0 on success; -1 on error setting errno. */
  int read_exact(int fd, void *data, size_t size); /* EOF => -1, errno=0 */
  int write_exact(int fd, const void *data, size_t size);
++#ifndef __MINIOS__
 +int writev_exact(int fd, const struct iovec *iov, int iovcnt);
++#endif
  
  int xc_ffs8(uint8_t x);
  int xc_ffs16(uint16_t x);

--- a/master/0003-HACK-tools-libxc-save-restore-v2-framework.patch
+++ b/master/0003-HACK-tools-libxc-save-restore-v2-framework.patch
@@ -132,10 +132,11 @@ diff --git a/tools/libxc/xc_domain_restore.c b/tools/libxc/xc_domain_restore.c
 index a0a7b9e..73939b8 100644
 --- a/tools/libxc/xc_domain_restore.c
 +++ b/tools/libxc/xc_domain_restore.c
-@@ -1502,6 +1502,14 @@ int xc_domain_restore(xc_interface *xch, int io_fd, uint32_t dom,
+@@ -1502,6 +1502,16 @@ int xc_domain_restore(xc_interface *xch, int io_fd, uint32_t dom,
      struct restore_ctx *ctx = &_ctx;
      struct domain_info_context *dinfo = &ctx->dinfo;
  
++#ifndef __MINIOS__
 +    if ( getenv("XG_MIGRATION_V2") )
 +    {
 +        return xc_domain_restore2(
@@ -143,6 +144,7 @@ index a0a7b9e..73939b8 100644
 +            store_domid, console_evtchn, console_mfn, console_domid,
 +            hvm,  pae,  superpages, checkpointed_stream, callbacks);
 +    }
++#endif
 +
      DPRINTF("%s: starting restore of new domid %u", __func__, dom);
  
@@ -151,15 +153,17 @@ diff --git a/tools/libxc/xc_domain_save.c b/tools/libxc/xc_domain_save.c
 index 02544f8..a23ed68 100644
 --- a/tools/libxc/xc_domain_save.c
 +++ b/tools/libxc/xc_domain_save.c
-@@ -894,6 +894,12 @@ int xc_domain_save(xc_interface *xch, int io_fd, uint32_t dom, uint32_t max_iter
+@@ -894,6 +894,14 @@ int xc_domain_save(xc_interface *xch, int io_fd, uint32_t dom, uint32_t max_iter
  
      int completed = 0;
  
++#ifndef __MINIOS__
 +    if ( getenv("XG_MIGRATION_V2") )
 +    {
 +        return xc_domain_save2(xch, io_fd, dom, max_iters,
 +                               max_factor, flags, callbacks, hvm);
 +    }
++#endif
 +
      DPRINTF("%s: starting save of domid %u", __func__, dom);
  

--- a/master/stubdoms_disable_CONFIG_MIGRATE.patch
+++ b/master/stubdoms_disable_CONFIG_MIGRATE.patch
@@ -1,0 +1,47 @@
+From 755a7aaee0944800ff8666715ec32b88775816b2 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 27 Jan 2015 16:58:06 +0000
+Subject: [PATCH] tools/libxc: Disable CONFIG_MIGRATE in stubdom environments
+
+The legacy save/restore infrastructure requires several function pointers from
+the toolstack (libxl or Xend in the past) in order to work, and for HVM guests
+also need to be able to play around in dom0's filesystem to move the device
+model save record.
+
+Migration v2 changes some of this, but is similarly dependent on
+toolstack-provided function pointers.
+
+Someone who wishes to re-architect the interaction of moving parts for running
+a domain might be in a position to re-enabled this, but for now, explicitly
+fail with ENOSYS (from xc_nomigrate.c) rather than failing with an error about
+a missing function pointer (or indeed falling over a NULL pointer on certain
+paths).
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+CC: Ian Campbell <Ian.Campbell@citrix.com>
+CC: Ian Jackson <Ian.Jackson@eu.citrix.com>
+CC: Wei Liu <wei.liu2@citrix.com>
+Acked-by: Ian Campbell <ian.campbell@citrix.com>
+---
+ tools/libxc/Makefile |    5 +++++
+ 1 files changed, 5 insertions(+), 0 deletions(-)
+
+diff --git a/tools/libxc/Makefile b/tools/libxc/Makefile
+index 7587d4c..6fa88c7 100644
+--- a/tools/libxc/Makefile
++++ b/tools/libxc/Makefile
+@@ -4,6 +4,11 @@ include $(XEN_ROOT)/tools/Rules.mk
+ MAJOR    = 4.5
+ MINOR    = 0
+ 
++ifeq ($(CONFIG_LIBXC_MINIOS),y)
++# Save/restore of a domain is currently incompatible with a stubdom environment
++override CONFIG_MIGRATE := n
++endif
++
+ CTRL_SRCS-y       :=
+ CTRL_SRCS-y       += xc_core.c
+ CTRL_SRCS-$(CONFIG_X86) += xc_core_x86.c
+-- 
+1.7.2.5
+


### PR DESCRIPTION
Fix compilation issue of stubdoms of Xen 4.5.0 with pq applied:

https://github.com/xenserver/buildroot/issues/615
